### PR TITLE
Expose individual wheel distances and velocities.

### DIFF
--- a/include/create/create.h
+++ b/include/create/create.h
@@ -73,8 +73,8 @@ namespace create {
 
       uint32_t prevTicksLeft;
       uint32_t prevTicksRight;
-      float prevLeftVel;
-      float prevRightVel;
+      float totalLeftDist;
+      float totalRightDist;
       bool firstOnData;
       util::timestamp_t prevOnDataTime;
 
@@ -443,6 +443,22 @@ namespace create {
       /* Return true if Create is moving forward, false otherwise.
        */
       bool isMovingForward() const;
+
+      /* Get the total distance (in meters) the left wheel has moved.
+       */
+      float getLeftWheelDistance() const;
+
+      /* Get the total distance (in meters) the right wheel has moved.
+       */
+      float getRightWheelDistance() const;
+
+      /* Get the requested velocity (in meters/sec) of the left wheel.
+       */
+      float getRequestedLeftWheelVel() const;
+
+      /* Get the requested velocity (in meters/sec) of the right wheel.
+       */
+      float getRequestedRightWheelVel() const;
 
       /* Get the current charging state.
        */

--- a/include/create/util.h
+++ b/include/create/util.h
@@ -40,6 +40,8 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace create {
   namespace util {
 
+    static const float CREATE_1_AXLE_LENGTH = 0.26;
+
     static const uint8_t CREATE_2_HEADER = 19;
     static const float CREATE_2_AXLE_LENGTH = 0.235;
     static const float CREATE_2_TICKS_PER_REV = 508.8;

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -26,6 +26,8 @@ namespace create {
     ADD_PACKET(ID_CAPACITY, 2, "battery_capacity");
     ADD_PACKET(ID_VIRTUAL_WALL, 1, "virtual_wall");
     ADD_PACKET(ID_OI_MODE, 1, "oi_mode");
+    ADD_PACKET(ID_RIGHT_VEL, 2, "velocity_right");
+    ADD_PACKET(ID_LEFT_VEL, 2, "velocity_left");
 
     if (model == CREATE_1) {
       ADD_PACKET(ID_DISTANCE, 2, "distance");
@@ -48,8 +50,6 @@ namespace create {
       //ADD_PACKET(ID_NUM_STREAM_PACKETS, 1, "oi_stream_num_packets");
       //ADD_PACKET(ID_VEL, 2, "velocity");
       //ADD_PACKET(ID_RADIUS, 2, "radius");
-      //ADD_PACKET(ID_RIGHT_VEL, 2, "velocity_right");
-      //ADD_PACKET(ID_LEFT_VEL, 2, "velocity_left");
       ADD_PACKET(ID_LEFT_ENC, 2, "enc_counts_left");
       ADD_PACKET(ID_RIGHT_ENC, 2, "enc_counts_right");
       ADD_PACKET(ID_LIGHT, 1, "light_bumper");


### PR DESCRIPTION
Adds new getters for individual wheel distances and velocities. This also fixes the existing wheel distance  calculation for the Create 1, which was not done correctly. This has been tested on the Create 1, but should work fine on the Create 2 also, as the code for calculating the wheel distance is very simple and was already in place.

This change is required to support AutonomyLab/create_autonomy#26