### PR TITLE
Fix odometry inversion for Create 1

### DIFF
--- a/src/create.cpp
+++ b/src/create.cpp
@@ -103,7 +103,7 @@ namespace create {
       deltaDist = ((int16_t) GET_DATA(ID_DISTANCE)) / 1000.0; //mm -> m
       deltaYaw = ((int16_t) GET_DATA(ID_ANGLE)) * (util::PI / 180.0); // D2R
       deltaX = deltaDist * cos( util::normalizeAngle(pose.yaw + deltaYaw) );
-      deltaY = -deltaDist * sin( util::normalizeAngle(pose.yaw + deltaYaw) );
+      deltaY = deltaDist * sin( util::normalizeAngle(pose.yaw + deltaYaw) );
       leftWheelDist = deltaDist / 2.0;
       rightWheelDist = leftWheelDist;
 


### PR DESCRIPTION
This PR fixes a bug that I think was inadvertently introduced by #12. On the Create 1, the y axis of the odometry is inverted. My guess is that you noticed the sign error when testing with the Create 2, but applied the fix to the odometry calculations for both the Create 1 and 2, when the problem only affected the Create 2.