### PR TITLE
updated setDigits function API comments

### DIFF
--- a/include/create/create.h
+++ b/include/create/create.h
@@ -278,17 +278,19 @@ namespace create {
       /**
        * \brief Set the four 7-segment display digits from left to right.
        *
-       * \todo This function is not yet implemented refer to https://github.com/AutonomyLab/libcreate/issues/7
+       * \todo This function is not yet implemented refer to https://github.com/AutonomyLab/libcreate/issues/7 
        * \param segments to enable (true) or disable (false).
        *        The size of segments should be less than 29.
        *        The ordering of segments is left to right, top to bottom for each digit:
        *
-       *            0           7             14            21
-       *          |‾‾‾|       |‾‾‾|         |‾‾‾|         |‾‾‾|
-       *        1 |___| 2   8 |___| 9    15 |___| 16   22 |___| 23
-       *          | 3 |       | 10|         | 17|         | 24|
-       *        4 |___| 5   11|___| 12   18 |___| 19   25 |___| 26
-       *            6           13            20            27
+       *     <pre>
+                 0           7             14            21 
+               |‾‾‾|       |‾‾‾|         |‾‾‾|         |‾‾‾|  
+             1 |___| 2   8 |___| 9    15 |___| 16   22 |___| 23 
+               | 3 |       | 10|         | 17|         | 24|
+             4 |___| 5   11|___| 12   18 |___| 19   25 |___| 26
+                 6           13            20            27
+            </pre>
        *
        * \return true if successful, false otherwise
        */


### PR DESCRIPTION
-added HTML to adjust for spacing in diagram, showing the proper ordering of segments. 
-note that if this doesn't work, you may need to add asterisks back to each line, and try a more manual approach (e.g., using &nbsp). 
For the API documentation parsing procedure used by ROS (for C++ packages), refer to:
http://www.stack.nl/~dimitri/doxygen/manual/htmlcmds.html