### PR TITLE
Enable to run on ROS Melodic

### DIFF
--- a/include/create/serial.h
+++ b/include/create/serial.h
@@ -40,13 +40,14 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <boost/thread/condition_variable.hpp>
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/enable_shared_from_this.hpp>
 
 #include "create/data.h"
 #include "create/types.h"
 #include "create/util.h"
 
 namespace create {
-  class Serial {
+  class Serial : public boost::enable_shared_from_this<Serial> {
 
     protected:
       boost::asio::io_service io;

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -186,10 +186,14 @@ namespace create {
     totalLeftDist += leftWheelDist;
     totalRightDist += rightWheelDist;
 
-    if (dt > 0.1) {
+    if (fabs(dt) > util::EPS) {
       vel.x = deltaDist / dt;
       vel.y = 0.0;
       vel.yaw = deltaYaw / dt;
+    } else {
+      vel.x = 0.0;
+      vel.y = 0.0;
+      vel.yaw = 0.0;
     }
 
     // Update covariances

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -186,14 +186,10 @@ namespace create {
     totalLeftDist += leftWheelDist;
     totalRightDist += rightWheelDist;
 
-    if (fabs(dt) > util::EPS) {
+    if (dt > 0.1) {
       vel.x = deltaDist / dt;
       vel.y = 0.0;
       vel.yaw = deltaYaw / dt;
-    } else {
-      vel.x = 0.0;
-      vel.y = 0.0;
-      vel.yaw = 0.0;
     }
 
     // Update covariances

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -72,7 +72,7 @@ namespace create {
     // Start continuously reading one byte at a time
     boost::asio::async_read(port,
                             boost::asio::buffer(&byteRead, 1),
-                            boost::bind(&Serial::onData, this, _1, _2));
+                            boost::bind(&Serial::onData, shared_from_this(), _1, _2));
 
     ioThread = boost::thread(boost::bind(&boost::asio::io_service::run, &io));
 
@@ -145,7 +145,7 @@ namespace create {
     // Read the next byte
     boost::asio::async_read(port,
                             boost::asio::buffer(&byteRead, 1),
-                            boost::bind(&Serial::onData, this, _1, _2));
+                            boost::bind(&Serial::onData, shared_from_this(), _1, _2));
   }
 
   bool Serial::send(const uint8_t* bytes, unsigned int numBytes) {


### PR DESCRIPTION
Solved https://github.com/AutonomyLab/create_autonomy/issues/54

When I used this package on Ubuntu 18.04 and ROS Melodic, I had the same problem above.

```
roslaunch ca_driver create_2.launch
...
[ INFO] [1549365785.956563724]: [CREATE] "CREATE_2" selected
[create::Serial] failed to receive data from Create. Check if robot is powered!
[create::Create] retrying to establish serial connection...
[create::Serial] serial error - Operation canceled
[create::Serial] failed to receive data from Create. Check if robot is powered!
[create::Create] retrying to establish serial connection...
[create::Serial] serial error - Operation canceled
...
```

This PR solves it based on https://github.com/AutonomyLab/create_autonomy/issues/54#issuecomment-450024493