### PR TITLE
Fix for compatibility with Boost 1.66

### DIFF
--- a/src/serial_query.cpp
+++ b/src/serial_query.cpp
@@ -44,7 +44,7 @@ namespace create {
 
   void SerialQuery::flushInput() {
     // Only works with POSIX support
-    tcflush(port.lowest_layer().native(), TCIFLUSH);
+    tcflush(port.lowest_layer().native_handle(), TCIFLUSH);
   }
 
   void SerialQuery::processByte(uint8_t byteRead) {


### PR DESCRIPTION
Compatibility with at least as early as Boost 1.58 still persists

Signed-off-by: Anton Gerasimov <tossel@gmail.com>