### PR TITLE
Enable to run on ROS 2 Crystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,13 @@ Note, the examples found in the "examples" directory are built with the library.
         cmake ..
         make -j
 
-#### catkin ####
+#### colcon ####
 
         mkdir -p create_ws/src
-        cd create_ws
-        catkin init
-        cd src
+        cd create_ws/src
         git clone https://github.com/AutonomyLab/libcreate.git
-        catkin build
+        cd ..
+        colcon build
 
 ## Running Tests ##
 

--- a/include/create/serial.h
+++ b/include/create/serial.h
@@ -40,13 +40,14 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <boost/thread/condition_variable.hpp>
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/enable_shared_from_this.hpp>
 
 #include "create/data.h"
 #include "create/types.h"
 #include "create/util.h"
 
 namespace create {
-  class Serial {
+  class Serial : public boost::enable_shared_from_this<Serial> {
 
     protected:
       boost::asio::io_service io;

--- a/package.xml
+++ b/package.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>libcreate</name>
-  <version>1.6.1</version>
+  <version>2.0.0</version>
   <description>C++ library for interfacing with iRobot's Create 1 and Create 2</description>
 
   <maintainer email="jperron@sfu.ca">Jacob Perron</maintainer>
+  <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
 
   <license>BSD</license>
 
@@ -14,17 +15,15 @@
 
   <author email="jperron@sfu.ca">Jacob Perron</author>
 
-  <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>boost</depend>
-
-  <exec_depend>catkin</exec_depend>
 
   <doc_depend>doxygen</doc_depend>
 
   <test_depend>gtest</test_depend>
 
   <export>
-    <build_type>cmake</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -72,7 +72,7 @@ namespace create {
     // Start continuously reading one byte at a time
     boost::asio::async_read(port,
                             boost::asio::buffer(&byteRead, 1),
-                            boost::bind(&Serial::onData, this, _1, _2));
+                            boost::bind(&Serial::onData, shared_from_this(), _1, _2));
 
     ioThread = boost::thread(boost::bind(&boost::asio::io_service::run, &io));
 
@@ -145,7 +145,7 @@ namespace create {
     // Read the next byte
     boost::asio::async_read(port,
                             boost::asio::buffer(&byteRead, 1),
-                            boost::bind(&Serial::onData, this, _1, _2));
+                            boost::bind(&Serial::onData, shared_from_this(), _1, _2));
   }
 
   bool Serial::send(const uint8_t* bytes, unsigned int numBytes) {


### PR DESCRIPTION
I want to build this package on ROS 2 environment but `rosdep` cannot resolve `catkin` dependency because it is for ROS 1 dependency.

```
rosdep install --from-paths src --ignore-src -r -y
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
libcreate: Cannot locate rosdep definition for [catkin]
Continuing to install resolvable dependencies...
#All required rosdeps installed successfully
```

This PR resolved it.
Please merge https://github.com/AutonomyLab/libcreate/pull/38 first.