### PR TITLE
Fix for compatibility with other compilers/environments

### DIFF
--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -21,7 +21,10 @@ namespace create {
   bool Serial::connect(const std::string& portName, const int& baud, boost::function<void()> cb) {
     using namespace boost::asio;
     port.open(portName);
-    port.set_option(serial_port::baud_rate(baud));
+	port.set_option(serial_port::baud_rate(baud));
+	port.set_option(serial_port::character_size(8));
+	port.set_option(serial_port::parity(serial_port::parity::none));
+	port.set_option(serial_port::stop_bits(serial_port::stop_bits::one));
     port.set_option(serial_port::flow_control(serial_port::flow_control::none));
 
     usleep(1000000);

--- a/src/serial_stream.cpp
+++ b/src/serial_stream.cpp
@@ -5,7 +5,7 @@
 
 namespace create {
 
-  SerialStream::SerialStream(boost::shared_ptr<Data> d, const uint8_t& header) : Serial(d), headerByte(header){
+  SerialStream::SerialStream(boost::shared_ptr<Data> d, const uint8_t& header) : Serial(d), headerByte(header), readState(READ_HEADER){
   }
 
   bool SerialStream::startSensorStream() {


### PR DESCRIPTION
* An initialization of a variable required. An undefined value results doing nothing in a switch-case statement.
* Explicit settings for all options of serial communication including stop bits, character size, and parity are required.