### PR TITLE
Disconnect from serial cleanly on SIGINT

### DIFF
--- a/include/create/serial.h
+++ b/include/create/serial.h
@@ -51,6 +51,7 @@ namespace create {
 
     protected:
       boost::asio::io_service io;
+      boost::asio::signal_set signals;
       boost::asio::serial_port port;
 
     private:
@@ -61,7 +62,6 @@ namespace create {
       bool isReading;
       bool firstRead;
       uint8_t byteRead;
-
 
       // Callback executed when data arrives from Create
       void onData(const boost::system::error_code& e, const std::size_t& size);
@@ -80,6 +80,7 @@ namespace create {
       virtual bool startSensorStream() = 0;
       virtual void processByte(uint8_t byteRead) = 0;
 
+      void signalHandler(const boost::system::error_code& error, int signal_number);
       // Notifies main thread that data is fresh and makes the user callback
       void notifyDataReady();
 

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -15,8 +15,6 @@ namespace create {
 
   namespace ublas = boost::numeric::ublas;
 
-  // TODO: Handle SIGINT to do clean disconnect
-
   void Create::init() {
     mainMotorPower = 0;
     sideMotorPower = 0;


### PR DESCRIPTION
Send the STOP opcode before exiting the program to ensure the robot is not left in a state that could potentially drain the battery.