### PR TITLE
Use OC_MOTORS instead of OC_MOTORS_PWM on V_1 models

### DIFF
--- a/src/create.cpp
+++ b/src/create.cpp
@@ -463,6 +463,15 @@ namespace create {
     sideMotorPower = roundf(side * 127);
     vacuumMotorPower = roundf(vacuum * 127);
 
+    if (model.getVersion() == V_1) {
+        uint8_t cmd[2] = { OC_MOTORS,
+                           (uint8_t)((side != 0.0 ? 1 : 0) |
+                                     (vacuum != 0.0 ? 2 : 0) |
+                                     (main != 0.0 ? 4 : 0))
+                         };
+        return serial->send(cmd, 2);
+    }
+
     uint8_t cmd[4] = { OC_MOTORS_PWM,
                        mainMotorPower,
                        sideMotorPower,

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -465,7 +465,7 @@ namespace create {
 
     if (model.getVersion() == V_1) {
         uint8_t cmd[2] = { OC_MOTORS,
-                           (uint8_t)((side != 0.0 ? 1 : 0) |
+                           static_cast<uint8_t>((side != 0.0 ? 1 : 0) |
                                      (vacuum != 0.0 ? 2 : 0) |
                                      (main != 0.0 ? 4 : 0))
                          };


### PR DESCRIPTION
SCI for older Roombas (V_1) did not include OC_MOTORS_PWM, but only OC_MOTORS. Use that instead of OC_MOTORS_PWM for V_1, interpeting values != 0 as "on".