### PR TITLE
Implement methods for getting overcurrent status

### DIFF
--- a/src/create.cpp
+++ b/src/create.cpp
@@ -1036,6 +1036,36 @@ namespace create {
     }
   }
 
+  bool Create::isSideBrushOvercurrent() const { 
+    if (data->isValidPacketID(ID_OVERCURRENTS)) {
+      return (GET_DATA(ID_OVERCURRENTS) & 0x01) != 0;
+    }
+    else {
+      CERR("[create::Create] ", "Overcurrent sensor not supported!");
+      return false;
+    }
+  }
+
+  bool Create::isMainBrushOvercurrent() const { 
+    if (data->isValidPacketID(ID_OVERCURRENTS)) {
+      return (GET_DATA(ID_OVERCURRENTS) & 0x04) != 0;
+    }
+    else {
+      CERR("[create::Create] ", "Overcurrent sensor not supported!");
+      return false;
+    }
+  }
+  
+  bool Create::isWheelOvercurrent() const { 
+    if (data->isValidPacketID(ID_OVERCURRENTS)) {
+      return (GET_DATA(ID_OVERCURRENTS) & 0x18) != 0;
+    }
+    else {
+      CERR("[create::Create] ", "Overcurrent sensor not supported!");
+      return false;
+    }
+  }
+
   float Create::getLeftWheelDistance() const {
     return totalLeftDist;
   }

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -17,7 +17,7 @@ namespace create {
     ADD_PACKET(ID_CLIFF_FRONT_RIGHT, 1, "cliff_front_right", V_ALL);
     ADD_PACKET(ID_CLIFF_RIGHT, 1, "cliff_right", V_ALL);
     ADD_PACKET(ID_VIRTUAL_WALL, 1, "virtual_wall", V_ALL);
-    ADD_PACKET(ID_OVERCURRENTS, 1, "overcurrents", V_1);
+    ADD_PACKET(ID_OVERCURRENTS, 1, "overcurrents", V_ALL);
     ADD_PACKET(ID_DIRT_DETECT_LEFT, 1, "dirt_detect_left", V_ALL);
     ADD_PACKET(ID_DIRT_DETECT_RIGHT, 1, "dirt_detect_right", V_1);
     ADD_PACKET(ID_IR_OMNI, 1, "ir_opcode", V_ALL);

--- a/tests/test_data.cpp
+++ b/tests/test_data.cpp
@@ -52,21 +52,21 @@ TEST(DataTest, Constructor)
 // Number of packets for a given protocol are determined in the Data() constructor
 TEST(DataTest, GetNumPackets)
 {
-  // Number of packets shared by all protocols is 16
+  // Number of packets shared by all protocols is 17
   create::Data data_v_1(create::V_1);
-  // Number exclusive to V_1 = 4
-  // 16 + 4 = 20
+  // Number exclusive to V_1 = 3
+  // 17 + 3 = 20
   EXPECT_EQ(static_cast<int>(data_v_1.getNumPackets()), 20);
 
   create::Data data_v_2(create::V_2);
   // Number exclusive to V_2 = 3
-  // 16 + 3 = 19
-  EXPECT_EQ(static_cast<int>(data_v_2.getNumPackets()), 19);
+  // 17 + 3 = 20
+  EXPECT_EQ(static_cast<int>(data_v_2.getNumPackets()), 20);
 
   create::Data data_v_3(create::V_3);
   // Number exclusive to V_3 = 13
-  // 16 + 13 = 29
-  EXPECT_EQ(static_cast<int>(data_v_3.getNumPackets()), 29);
+  // 17 + 13 = 30
+  EXPECT_EQ(static_cast<int>(data_v_3.getNumPackets()), 30);
 
   create::Data data_v_all(create::V_ALL);
   EXPECT_EQ(static_cast<int>(data_v_all.getNumPackets()), 33);
@@ -108,7 +108,7 @@ TEST(DataTest, GetPacketIDs)
   create::Data data_v_3(create::V_3);
   const std::vector<uint8_t> packet_ids = data_v_3.getPacketIDs();
   // Vector should have same length as reported by getNumPackets()
-  ASSERT_EQ(static_cast<int>(packet_ids.size()), 29);
+  ASSERT_EQ(static_cast<int>(packet_ids.size()), 30);
 
   // Vector should contain ID_LEFT_ENC
   bool found = false;
@@ -124,18 +124,18 @@ TEST(DataTest, GetPacketIDs)
 
 TEST(DataTest, GetTotalDataBytes)
 {
-  // All protocols have 20 mutual data bytes
-  // V_1 has an additional 6 bytes
+  // All protocols have 21 mutual data bytes
+  // V_1 has an additional 5 bytes
   create::Data data_v_1(create::V_1);
   EXPECT_EQ(static_cast<int>(data_v_1.getTotalDataBytes()), 26);
 
   // V_2 has an additional 5 bytes
   create::Data data_v_2(create::V_2);
-  EXPECT_EQ(static_cast<int>(data_v_2.getTotalDataBytes()), 25);
+  EXPECT_EQ(static_cast<int>(data_v_2.getTotalDataBytes()), 26);
 
   // V_3 has an additional 21 bytes
   create::Data data_v_3(create::V_3);
-  EXPECT_EQ(static_cast<int>(data_v_3.getTotalDataBytes()), 41);
+  EXPECT_EQ(static_cast<int>(data_v_3.getTotalDataBytes()), 42);
 }
 
 TEST(DataTest, IsValidPacketID)


### PR DESCRIPTION
Provides the non-implemented methods for getting the overcurrent status of the brush and wheel motors, regarding issue #8 .
Also marks the overcurrent packet as applicable to all protocol versions and updates the tests to reflect this.