### PR TITLE
Use average dt values for velocity calculation

### DIFF
--- a/include/create/create.h
+++ b/include/create/create.h
@@ -37,6 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <string>
 #include <unistd.h>
+#include <deque>
 
 #include "create/serial_stream.h"
 #include "create/serial_query.h"
@@ -81,6 +82,8 @@ namespace create {
       float totalRightDist;
       bool firstOnData;
       std::chrono::time_point<std::chrono::steady_clock> prevOnDataTime;
+      std::deque<float> dtHistory;
+      uint8_t dtHistoryLength;
 
       Matrix poseCovar;
 
@@ -331,6 +334,14 @@ namespace create {
        * \return true if successful, false otherwise
        */
       bool playSong(const uint8_t& songNumber) const;
+
+      /**
+       * \brief Set dtHistoryLength parameter.
+       * Used to configure the size of the buffer for calculating average time delta (dt).
+       * between onData calls, which in turn is used for velocity calculation.
+       * \param dtHistoryLength number of historical samples to use for calculating average dt.
+       */
+      void setDtHistoryLength(const uint8_t& dtHistoryLength);
 
       /**
        * \return true if a left or right wheeldrop is detected, false otherwise.


### PR DESCRIPTION
Fixes #36 

Tested on my Create2, running Ubuntu 18.04 on a Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz (Intel NUC).

The underlying issue appears to be that `dt` values between `onData` calls do not accurately represent the `dt` values at which the encoders are sampled. It appears that averaging the `onData` `dt` values yields more accurate results. 