### PR TITLE
Add option to disable signal handlers

### DIFF
--- a/include/create/create.h
+++ b/include/create/create.h
@@ -92,7 +92,7 @@ namespace create {
       float requestedLeftVel;
       float requestedRightVel;
 
-      void init();
+      void init(bool install_signal_handler);
       // Add two matrices and handle overflow case
       Matrix addMatrices(const Matrix &A, const Matrix &B) const;
       void onData();
@@ -109,8 +109,10 @@ namespace create {
        * Calling this constructor Does not attempt to establish a serial connection to the robot.
        *
        * \param model the type of the robot. See RobotModel to determine the value for your robot.
-        */
-      Create(RobotModel model = RobotModel::CREATE_2);
+       * \param install_signal_handler if true, then register a signal handler to disconnect from
+       *   the robot on SIGINT or SIGTERM.
+       */
+      Create(RobotModel model = RobotModel::CREATE_2, bool install_signal_handler = true);
 
       /**
        * \brief Attempts to establish serial connection to Create.
@@ -119,8 +121,10 @@ namespace create {
        * \param baud rate to communicate with Create. Typically,
        *        115200 for Create 2 and 57600 for Create 1.
        * \param model type of robot. See RobotModel to determine the value for your robot.
+       * \param install_signal_handler if true, then register a signal handler to disconnect from
+       *   the robot on SIGINT or SIGTERM.
        */
-      Create(const std::string& port, const int& baud, RobotModel model = RobotModel::CREATE_2);
+      Create(const std::string& port, const int& baud, RobotModel model = RobotModel::CREATE_2, bool install_signal_handler = true);
 
       /**
        * \brief Attempts to disconnect from serial.

--- a/include/create/serial.h
+++ b/include/create/serial.h
@@ -86,7 +86,7 @@ namespace create {
       void notifyDataReady();
 
     public:
-      Serial(std::shared_ptr<Data> data);
+      Serial(std::shared_ptr<Data> data, bool install_signal_handler);
       ~Serial();
       bool connect(const std::string& port, const int& baud = 115200, std::function<void()> cb = 0);
       void disconnect();

--- a/include/create/serial_query.h
+++ b/include/create/serial_query.h
@@ -67,7 +67,7 @@ namespace create {
       void processByte(uint8_t byteRead);
 
     public:
-      SerialQuery(std::shared_ptr<Data> data);
+      SerialQuery(std::shared_ptr<Data> data, bool install_signal_handler = true);
   };
 }  // namespace create
 

--- a/include/create/serial_stream.h
+++ b/include/create/serial_stream.h
@@ -69,7 +69,10 @@ namespace create {
       void processByte(uint8_t byteRead);
 
     public:
-      SerialStream(std::shared_ptr<Data> data, const uint8_t& header = create::util::STREAM_HEADER);
+      SerialStream(
+        std::shared_ptr<Data> data,
+        const uint8_t& header = create::util::STREAM_HEADER,
+        bool install_signal_handler = true);
 
   };
 }  // namespace create

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -14,7 +14,7 @@ namespace create {
 
   namespace ublas = boost::numeric::ublas;
 
-  void Create::init() {
+  void Create::init(bool install_signal_handler) {
     mainMotorPower = 0;
     sideMotorPower = 0;
     vacuumMotorPower = 0;
@@ -44,18 +44,21 @@ namespace create {
     dtHistoryLength = 100;
     data = std::shared_ptr<Data>(new Data(model.getVersion()));
     if (model.getVersion() == V_1) {
-      serial = std::make_shared<SerialQuery>(data);
+      serial = std::make_shared<SerialQuery>(data, install_signal_handler);
     } else {
-      serial = std::make_shared<SerialStream>(data);
+      serial = std::make_shared<SerialStream>(
+        data, create::util::STREAM_HEADER, install_signal_handler);
     }
   }
 
-  Create::Create(RobotModel m) : model(m) {
-    init();
+  Create::Create(RobotModel m, bool install_signal_handler) : model(m) {
+    init(install_signal_handler);
   }
 
-  Create::Create(const std::string& dev, const int& baud, RobotModel m) : model(m) {
-    init();
+  Create::Create(const std::string& dev, const int& baud, RobotModel m, bool install_signal_handler)
+    : model(m)
+  {
+    init(install_signal_handler);
     serial->connect(dev, baud);
   }
 

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -7,14 +7,19 @@
 
 namespace create {
 
-  Serial::Serial(std::shared_ptr<Data> d) :
-    signals(io, SIGINT, SIGTERM),
+  Serial::Serial(std::shared_ptr<Data> d, bool install_signal_handler) :
+    signals(io),
     port(io),
     dataReady(false),
     isReading(false),
     data(d),
     corruptPackets(0),
-    totalPackets(0) {
+    totalPackets(0)
+  {
+    if (install_signal_handler) {
+      signals.add(SIGINT);
+      signals.add(SIGTERM);
+    }
   }
 
   Serial::~Serial() {

--- a/src/serial_query.cpp
+++ b/src/serial_query.cpp
@@ -8,7 +8,8 @@
 
 namespace create {
 
-  SerialQuery::SerialQuery(std::shared_ptr<Data> d) : Serial(d),
+  SerialQuery::SerialQuery(std::shared_ptr<Data> d, bool install_signal_handler)
+  : Serial(d, install_signal_handler),
     streamRecoveryTimer(io),
     packetID(ID_BUMP_WHEELDROP),
     packetByte(0),

--- a/src/serial_stream.cpp
+++ b/src/serial_stream.cpp
@@ -6,7 +6,7 @@
 
 namespace create {
 
-  SerialStream::SerialStream(std::shared_ptr<Data> d, const uint8_t& header) : Serial(d), readState(READ_HEADER), headerByte(header) {
+  SerialStream::SerialStream(std::shared_ptr<Data> d, const uint8_t& header, bool install_signal_handler) : Serial(d, install_signal_handler), readState(READ_HEADER), headerByte(header) {
   }
 
   bool SerialStream::startSensorStream() {


### PR DESCRIPTION
This gives the user the option to create their own signal handler without having create::Create interfere.
They can disable the sigint/sigterm handler and be responsible for disconnecting from the robot themselves.