### PR TITLE
Catch Boost Exceptions + Address some warnings

### DIFF
--- a/include/create/serial.h
+++ b/include/create/serial.h
@@ -71,6 +71,8 @@ namespace create {
       // Start and stop reading data from Create
       bool startReading();
       void stopReading();
+      bool openPort(const std::string& portName, const int& baud);
+      bool closePort();
 
     protected:
       std::shared_ptr<Data> data;

--- a/include/create/serial_query.h
+++ b/include/create/serial_query.h
@@ -68,6 +68,7 @@ namespace create {
 
     public:
       SerialQuery(std::shared_ptr<Data> data, bool install_signal_handler = true);
+      virtual ~SerialQuery() = default;
   };
 }  // namespace create
 

--- a/include/create/serial_stream.h
+++ b/include/create/serial_stream.h
@@ -73,6 +73,7 @@ namespace create {
         std::shared_ptr<Data> data,
         const uint8_t& header = create::util::STREAM_HEADER,
         bool install_signal_handler = true);
+      virtual ~SerialStream() = default;
 
   };
 }  // namespace create

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -160,10 +160,10 @@ namespace create {
       prevTicksRight = totalTicksRight;
 
       // Handle wrap around
-      if (fabs(ticksLeft) > 0.9 * util::V_3_MAX_ENCODER_TICKS) {
+      if (std::abs(ticksLeft) > 0.9 * util::V_3_MAX_ENCODER_TICKS) {
         ticksLeft = (ticksLeft % util::V_3_MAX_ENCODER_TICKS) + 1;
       }
-      if (fabs(ticksRight) > 0.9 * util::V_3_MAX_ENCODER_TICKS) {
+      if (std::abs(ticksRight) > 0.9 * util::V_3_MAX_ENCODER_TICKS) {
         ticksRight = (ticksRight % util::V_3_MAX_ENCODER_TICKS) + 1;
       }
 
@@ -373,7 +373,7 @@ namespace create {
         min > 59)
       return false;
 
-    uint8_t cmd[4] = { OC_DATE, day, hour, min };
+    uint8_t cmd[4] = { OC_DATE, static_cast<uint8_t>(day), hour, min };
     return serial->send(cmd, 4);
   }
 


### PR DESCRIPTION
_this PR addresses a couple of (minor) issues I ran into while test driving this library. Otherwise, it's working great so far!_

Changes:
- In `Serial`, wrap try/catch around boost asio calls that throw
- `static_cast` enum to uint8 instead of implicit (this was coming up as a compile error for me)
- change `fabs` -> `std::abs` in a couple places (compile warnings)
- add virtual destructors to `Serial` child classes (compile warnings)